### PR TITLE
Fix TypeScript compilation error in backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "ts-node src/index.ts",
     "build": "tsc",
     "watch": "tsc --watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "type-check": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,7 +11,7 @@ dotenv.config();
 
 // Create Express server
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = Number(process.env.PORT) || 3001;
 
 
 // Enhanced CORS configuration with debug logging


### PR DESCRIPTION
Fix TypeScript compilation error related to argument type assignment in `backend/src/index.ts`.

* **backend/src/index.ts**
  - Cast `PORT` variable to a number before passing to `app.listen` method.
  - Update the `PORT` variable assignment to `const PORT = Number(process.env.PORT) || 3001;`.

* **backend/package.json**
  - Add a type check script to the `scripts` section: `"type-check": "tsc --noEmit"`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PierrunoYT/OpenWriter/pull/2?shareId=c392c1d5-ecf8-472a-9ef2-2c05a95d45bf).